### PR TITLE
When setting UseHwnd=No in a PB.ini file, datastores won't show the p…

### DIFF
--- a/PFC.pbw
+++ b/PFC.pbw
@@ -9,6 +9,6 @@ Save Format v3.0(19990112)
  4 "security\\pfcsecsc\\security scanner.pbt";
  5 "examples\\appexamp\\pfc examples.pbt";
 @end;
-DefaultTarget "pfcapp\\generic_pfc_app.pbt";
+DefaultTarget "examples\\appexamp\\pfc examples.pbt";
 DefaultExportEncode "UTF-8";
-DefaultRemoteTarget "pfcapp\\generic_pfc_app.pbt";
+DefaultRemoteTarget "examples\\appexamp\\pfc examples.pbt";

--- a/ws_objects/pfcmain/pfcmain.pbl.src/pfc_u_dw_for_ds_print.sru
+++ b/ws_objects/pfcmain/pfcmain.pbl.src/pfc_u_dw_for_ds_print.sru
@@ -1,0 +1,76 @@
+﻿$PBExportHeader$pfc_u_dw_for_ds_print.sru
+forward
+global type pfc_u_dw_for_ds_print from u_dw
+end type
+end forward
+
+global type pfc_u_dw_for_ds_print from u_dw
+end type
+global pfc_u_dw_for_ds_print pfc_u_dw_for_ds_print
+
+type variables
+private:
+	boolean ib_usercancelled = true
+
+end variables
+
+forward prototypes
+public function integer of_printsetup (readonly long al_pages)
+end prototypes
+
+public function integer of_printsetup (readonly long al_pages);/////////////////////////////////////////////////////////////////////////
+//
+// Display print dialog to set print specs needed for Datastore printing
+//
+/////////////////////////////////////////////////////////////////////////
+integer li_rc
+this.modify ( 'datawindow.print.preview=yes' )
+do
+	// Insert rows until pagecount is the same as source DS. 
+	// This is needed so the user can set the desired pages in the print dialog.
+	this.insertrow( 0 )
+  // I have not encountered an issue with this so far but There may be
+  // a need for  safeguarding against a potential infinite loop here.
+  // To be safe, maybe add a counter variable and exit the loop
+  // when an implausibly high loop count is hit.
+loop while long ( this.describe ("evaluate('pagecount()'," + string ( this.rowcount() ) + ")")) < al_pages
+this.modify ( 'datawindow.print.preview=no' )
+
+// We only want the print dialog to set all the specs to the DW so printing is cancelled
+// immediately in printstart(). Therefore print() itself will *always* return -1 here.
+// In order to still correctly identify the user pressing "Cancel" during the print dialog, this flag is set to true.
+// If it wasn't reset to false in printstart(), we know that the dialog was cancelled by the user.
+ib_usercancelled = true
+this.print( true, true )
+if not ib_usercancelled then
+  // continue printing the DS
+	li_rc = 1
+else
+  // dialog was cancelled by user, return -1 accordingly
+	li_rc = -1
+end if
+// reset flag to default
+ib_usercancelled = true
+return li_rc
+
+end function
+
+on pfc_u_dw_for_ds_print.create
+call super::create
+end on
+
+on pfc_u_dw_for_ds_print.destroy
+call super::destroy
+end on
+
+event printstart;call super::printstart;/////////////////////////////////////////////////////////////////////////
+//
+// Cancel print immediately.
+// At this point the print dialog was OK'd so set ib_usercancelled to false
+// 
+/////////////////////////////////////////////////////////////////////////
+ib_usercancelled = false
+this.printcancel( )
+
+end event
+

--- a/ws_objects/pfcmain/pfcmain.pbl.src/pfc_w_ds_print.srw
+++ b/ws_objects/pfcmain/pfcmain.pbl.src/pfc_w_ds_print.srw
@@ -1,0 +1,21 @@
+﻿$PBExportHeader$pfc_w_ds_print.srw
+forward
+global type pfc_w_ds_print from w_master
+end type
+end forward
+
+global type pfc_w_ds_print from w_master
+boolean visible = false
+integer width = 690
+integer height = 568
+end type
+global pfc_w_ds_print pfc_w_ds_print
+
+on pfc_w_ds_print.create
+call super::create
+end on
+
+on pfc_w_ds_print.destroy
+call super::destroy
+end on
+

--- a/ws_objects/pfcmain/pfcmain.pbl.src/pfc_w_master.srw
+++ b/ws_objects/pfcmain/pfcmain.pbl.src/pfc_w_master.srw
@@ -3922,7 +3922,7 @@ ElseIf li_rc < 0 Then
 					"The information entered does not pass validation and "  + &
 					"must be corrected before changes can be saved.~r~n~r~n" + &
 					"Close without saving changes?", &
-					exclamation!, YesNo!, 2)
+					Question!, YesNo!, 2)
 	End If
 	If li_msg = 1 Then
 		ib_closestatus = False
@@ -3942,7 +3942,7 @@ Else
 	Else
 		li_msg = of_MessageBox ("pfc_master_closequery_savechanges", &
 					gnv_app.iapp_object.DisplayName, &
-					"Do you want to save changes?", exclamation!, YesNoCancel!, 1)
+					"Do you want to save changes?", Question!, YesNoCancel!, 1)
 	End If
 	Choose Case li_msg
 		Case 1

--- a/ws_objects/pfemain/pfemain.pbl.src/u_dw_for_ds_print.sru
+++ b/ws_objects/pfemain/pfemain.pbl.src/u_dw_for_ds_print.sru
@@ -1,0 +1,18 @@
+﻿$PBExportHeader$u_dw_for_ds_print.sru
+forward
+global type u_dw_for_ds_print from pfc_u_dw_for_ds_print
+end type
+end forward
+
+global type u_dw_for_ds_print from pfc_u_dw_for_ds_print
+end type
+global u_dw_for_ds_print u_dw_for_ds_print
+
+on u_dw_for_ds_print.create
+call super::create
+end on
+
+on u_dw_for_ds_print.destroy
+call super::destroy
+end on
+

--- a/ws_objects/pfemain/pfemain.pbl.src/w_ds_print.srw
+++ b/ws_objects/pfemain/pfemain.pbl.src/w_ds_print.srw
@@ -1,0 +1,18 @@
+﻿$PBExportHeader$w_ds_print.srw
+forward
+global type w_ds_print from pfc_w_ds_print
+end type
+end forward
+
+global type w_ds_print from pfc_w_ds_print
+end type
+global w_ds_print w_ds_print
+
+on w_ds_print.create
+call super::create
+end on
+
+on w_ds_print.destroy
+call super::destroy
+end on
+


### PR DESCRIPTION
When setting UseHwnd=No in a PB.ini file, _datastores_ won't show the printSetup() dialog when doing a _Print(true, true)_. This is a workaround, provided by Benjamin Gaesslein, which is based on calling "of_SetLegacyPrint(FALSE)" in the n_ds object.
The only problem is that when printing to "MS PDF Printer" you'll be prompted twice for the name of the pdf file to be saved. (Still it's a lot better than not seeing the Printsetup dialog at all).  When using "Cute PDF Writer" this doesn't happen. 
The **developer him/herself is responsible** for knowing the setting in the pb.ini file and calling "of_setLegacyPrint(**FALSE**)" in the constructor of the "n_ds" object, if he/she has a setting of "UseHwnd=**No**" in the pb.ini.

Except for the MS PDF printer, it seems to be an improvement. I'll still try to see if there's a way to solve that.
regards
MiguelL