### PR TITLE
Update to version 1509 with the following Warnings:

### DIFF
--- a/PFC.pbw
+++ b/PFC.pbw
@@ -9,6 +9,6 @@ Save Format v3.0(19990112)
  4 "security\\pfcsecsc\\security scanner.pbt";
  5 "examples\\appexamp\\pfc examples.pbt";
 @end;
-DefaultTarget "examples\\appexamp\\pfc examples.pbt";
+DefaultTarget "pfcapp\\generic_pfc_app.pbt";
 DefaultExportEncode "UTF-8";
-DefaultRemoteTarget "examples\\appexamp\\pfc examples.pbt";
+DefaultRemoteTarget "pfcapp\\generic_pfc_app.pbt";

--- a/ws_objects/pfcapp/pfcapp.pbl.src/generic_pfc_app.sra
+++ b/ws_objects/pfcapp/pfcapp.pbl.src/generic_pfc_app.sra
@@ -14,7 +14,7 @@ n_cst_appmanager gnv_app
 end variables
 
 global type generic_pfc_app from application
- string appruntimeversion = "21.0.0.1311"
+ string appruntimeversion = "21.0.0.1509"
 end type
 global generic_pfc_app generic_pfc_app
 

--- a/ws_objects/tutorial/pfctutor.pbl.src/pfctutor.sra
+++ b/ws_objects/tutorial/pfctutor.pbl.src/pfctutor.sra
@@ -14,7 +14,7 @@ n_cst_appmanager   gnv_app
 end variables
 
 global type pfctutor from application
- string appruntimeversion = "21.0.0.1311"
+ string appruntimeversion = "21.0.0.1509"
 end type
 global pfctutor pfctutor
 


### PR DESCRIPTION
 ---------- Compiler: Warnings   (10:41:14)
exmmain.pbl(n_tr).n_tr.Object Variable Declarations.1: Information C0146: The identifier 'n_tr' conflicts with an existing global variable with this name. The new definition of 'n_tr' will take precedence and the prior value will be ignored until this version of 'n_tr' goes out of scope.
exmmain.pbl(u_calendar).u_calendar.Object Variable Declarations.1: Information C0146: The identifier 'u_calendar' conflicts with an existing global variable with this name. The new definition of 'u_calendar' will take precedence and the prior value will be ignored until this version of 'u_calendar' goes out of scope.
exmmain.pbl(w_frame).w_frame.Object Variable Declarations.1: Information C0146: The identifier 'w_frame' conflicts with an existing global variable with this name. The new definition of 'w_frame' will take precedence and the prior value will be ignored until this version of 'w_frame' goes out of scope.
exmmain.pbl(w_master).w_master.Object Variable Declarations.1: Information C0146: The identifier 'w_master' conflicts with an existing global variable with this name. The new definition of 'w_master' will take precedence and the prior value will be ignored until this version of 'w_master' goes out of scope.
exmutil.pbl(n_cst_debug).n_cst_debug.Object Variable Declarations.1: Information C0146: The identifier 'n_cst_debug' conflicts with an existing global variable with this name. The new definition of 'n_cst_debug' will take precedence and the prior value will be ignored until this version of 'n_cst_debug' goes out of scope.
exmutil.pbl(n_cst_sqlspy).n_cst_sqlspy.Object Variable Declarations.1: Information C0146: The identifier 'n_cst_sqlspy' conflicts with an existing global variable with this name. The new definition of 'n_cst_sqlspy' will take precedence and the prior value will be ignored until this version of 'n_cst_sqlspy' goes out of scope.
exmutil.pbl(w_debuglog).w_debuglog.Object Variable Declarations.1: Information C0146: The identifier 'w_debuglog' conflicts with an existing global variable with this name. The new definition of 'w_debuglog' will take precedence and the prior value will be ignored until this version of 'w_debuglog' goes out of scope.
exmutil.pbl(w_sqlspy).w_sqlspy.Object Variable Declarations.1: Information C0146: The identifier 'w_sqlspy' conflicts with an existing global variable with this name. The new definition of 'w_sqlspy' will take precedence and the prior value will be ignored until this version of 'w_sqlspy' goes out of scope.
exmwnsrv.pbl(m_master).m_master.Object Variable Declarations.1: Information C0146: The identifier 'm_master' conflicts with an existing global variable with this name. The new definition of 'm_master' will take precedence and the prior value will be ignored until this version of 'm_master' goes out of scope.
exmwnsrv.pbl(n_cst_winsrv_statusbar).n_cst_winsrv_statusbar.Object Variable Declarations.1: Information C0146: The identifier 'n_cst_winsrv_statusbar' conflicts with an existing global variable with this name. The new definition of 'n_cst_winsrv_statusbar' will take precedence and the prior value will be ignored until this version of 'n_cst_winsrv_statusbar' goes out of scope.
pfemain.pbl(n_tr).n_tr.Object Variable Declarations.1: Information C0146: The identifier 'n_tr' conflicts with an existing global variable with this name. The new definition of 'n_tr' will take precedence and the prior value will be ignored until this version of 'n_tr' goes out of scope.
pfemain.pbl(u_calendar).u_calendar.Object Variable Declarations.1: Information C0146: The identifier 'u_calendar' conflicts with an existing global variable with this name. The new definition of 'u_calendar' will take precedence and the prior value will be ignored until this version of 'u_calendar' goes out of scope.
pfemain.pbl(w_frame).w_frame.Object Variable Declarations.1: Information C0146: The identifier 'w_frame' conflicts with an existing global variable with this name. The new definition of 'w_frame' will take precedence and the prior value will be ignored until this version of 'w_frame' goes out of scope.
pfemain.pbl(w_master).w_master.Object Variable Declarations.1: Information C0146: The identifier 'w_master' conflicts with an existing global variable with this name. The new definition of 'w_master' will take precedence and the prior value will be ignored until this version of 'w_master' goes out of scope.
pfeutil.pbl(n_cst_debug).n_cst_debug.Object Variable Declarations.1: Information C0146: The identifier 'n_cst_debug' conflicts with an existing global variable with this name. The new definition of 'n_cst_debug' will take precedence and the prior value will be ignored until this version of 'n_cst_debug' goes out of scope.
pfeutil.pbl(n_cst_sqlspy).n_cst_sqlspy.Object Variable Declarations.1: Information C0146: The identifier 'n_cst_sqlspy' conflicts with an existing global variable with this name. The new definition of 'n_cst_sqlspy' will take precedence and the prior value will be ignored until this version of 'n_cst_sqlspy' goes out of scope.
pfeutil.pbl(w_debuglog).w_debuglog.Object Variable Declarations.1: Information C0146: The identifier 'w_debuglog' conflicts with an existing global variable with this name. The new definition of 'w_debuglog' will take precedence and the prior value will be ignored until this version of 'w_debuglog' goes out of scope.
pfeutil.pbl(w_sqlspy).w_sqlspy.Object Variable Declarations.1: Information C0146: The identifier 'w_sqlspy' conflicts with an existing global variable with this name. The new definition of 'w_sqlspy' will take precedence and the prior value will be ignored until this version of 'w_sqlspy' goes out of scope.
pfewnsrv.pbl(m_master).m_master.Object Variable Declarations.1: Information C0146: The identifier 'm_master' conflicts with an existing global variable with this name. The new definition of 'm_master' will take precedence and the prior value will be ignored until this version of 'm_master' goes out of scope.
pfewnsrv.pbl(n_cst_winsrv_statusbar).n_cst_winsrv_statusbar.Object Variable Declarations.1: Information C0146: The identifier 'n_cst_winsrv_statusbar' conflicts with an existing global variable with this name. The new definition of 'n_cst_winsrv_statusbar' will take precedence and the prior value will be ignored until this version of 'n_cst_winsrv_statusbar' goes out of scope.
